### PR TITLE
[hotfix][docs] Clarify direct buffer memory defaults and configuratio…

### DIFF
--- a/docs/content/docs/deployment/memory/mem_trouble.md
+++ b/docs/content/docs/deployment/memory/mem_trouble.md
@@ -54,6 +54,18 @@ You can try to increase its limit by adjusting direct off-heap memory.
 See also how to configure off-heap memory for [TaskManagers]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#configure-off-heap-memory-direct-or-native),
 [JobManagers]({{< ref "docs/deployment/memory/mem_setup_jobmanager" >}}#configure-off-heap-memory) and the [JVM arguments]({{< ref "docs/deployment/memory/mem_setup" >}}#jvm-parameters) which Flink sets.
 
+> **Note:** In recent versions of Flink (1.17+), the configuration
+> parameter `<code>taskmanager.memory.network.direct</code>` determines
+> the fraction of memory allocated for network buffers/direct memory.
+> If encountering this error, verify that:
+>
+> 1. The configured network buffer/direct memory fraction is appropriate.
+> 2. Sum of total JVM heap + managed memory + direct memory stays within the
+>    limits of your container or machine.
+> 3. No external library or user code is allocating unmanaged off-heap memory
+>    outside of Flink's memory management.
+
+
 ## OutOfMemoryError: Metaspace
 
 The exception usually indicates that [JVM metaspace limit]({{< ref "docs/deployment/memory/mem_setup" >}}#jvm-parameters) is configured too small.


### PR DESCRIPTION
This PR enhances the "OutOfMemoryError: Direct buffer memory" section
in `mem_trouble.md` to clarify behavior in newer Flink versions.

- Notes that `taskmanager.memory.network.direct` controls direct buffer memory fraction.
- Reminds users to ensure heap + managed + direct memory stay within container/machine limits.
- Advises on checking for unmanaged off-heap allocations in user code or dependencies.

Docs-only change. No behavior change.

